### PR TITLE
Use the first qualifying meta tag

### DIFF
--- a/lib/guess_html_encoding.rb
+++ b/lib/guess_html_encoding.rb
@@ -22,7 +22,7 @@ module GuessHtmlEncoding
 
       meta_tags_regex = /
       (?:
-        <meta[^>]*HTTP-EQUIV=["']?Content-Type["']?[^>]*content=["'][^'"]*charset\s*=\s*([\w\d-]+)[;"']  # http-equiv
+        <meta[^>]*HTTP-EQUIV=["']?Content-Type["']?[^>]*content=["'][^'"]*charset\s*=\s*([^"'\;\s]+)  # http-equiv
         |                                                                                              # or
         <meta\s+charset=["']([\w\d-]+)?                                                                # charset
       )/ix

--- a/lib/guess_html_encoding.rb
+++ b/lib/guess_html_encoding.rb
@@ -22,7 +22,7 @@ module GuessHtmlEncoding
 
       meta_tags_regex = /
       (?:
-        <meta\s*HTTP-EQUIV=["']?Content-Type["']?[^>]*content=["'][^'"]*charset\s*=\s*([\w\d-]+)[;"']  # http-equiv
+        <meta[^>]*HTTP-EQUIV=["']?Content-Type["']?[^>]*content=["'][^'"]*charset\s*=\s*([\w\d-]+)[;"']  # http-equiv
         |                                                                                              # or
         <meta\s+charset=["']([\w\d-]+)?                                                                # charset
       )/ix

--- a/lib/guess_html_encoding.rb
+++ b/lib/guess_html_encoding.rb
@@ -19,11 +19,20 @@ module GuessHtmlEncoding
     end
 
     if out.nil? || out.empty? || !encoding_loaded?(out)
-      if html =~ /<meta[^>]*HTTP-EQUIV=["']?Content-Type["']?[^>]*content=["']([^'"]*)["']/i && $1 =~ /charset=([\w\d-]+);?/i
-        out = $1
-      elsif html =~ /<meta\s+charset=["']([\w\d-]+)?/i
-        out = $1
+
+      meta_tags_regex = /
+      (?:
+        <meta\s*HTTP-EQUIV=["']?Content-Type["']?[^>]*content=["'][^'"]*charset\s*=\s*([\w\d-]+)[;"']  # http-equiv
+        |                                                                                              # or
+        <meta\s+charset=["']([\w\d-]+)?                                                                # charset
+      )/ix
+
+      meta_match = html.match(meta_tags_regex)
+
+      if meta_match
+        out = meta_match[1] || meta_match[2]
       end
+
       out.upcase! unless out.nil?
     end
 

--- a/spec/guess_html_encoding_spec.rb
+++ b/spec/guess_html_encoding_spec.rb
@@ -57,6 +57,11 @@ describe "GuessHtmlEncoding" do
       expect(guess).to eq("GB18030")
     end
     
+    it "will use the first qualifying meta tag" do
+      guess = GuessHtmlEncoding.guess('<html<head><meta charset="iso-8859-1" /><meta http-equiv="Content-Type" content="text/html;charset=UTF-8" /></body></html>')
+      expect(guess).to eq("ISO-8859-1")
+    end
+
     it "should not raise an exception if data is nil" do
       expect { GuessHtmlEncoding.guess(nil) }.not_to raise_error
     end

--- a/spec/guess_html_encoding_spec.rb
+++ b/spec/guess_html_encoding_spec.rb
@@ -16,7 +16,7 @@ describe "GuessHtmlEncoding" do
     end
 
     it "accepts meta tags" do
-      guess = GuessHtmlEncoding.guess('<html><head><meta http-equiv="content-type" content="text/html; charset=LATIN1"></head><body><div>hi!</div></body></html>')
+      guess = GuessHtmlEncoding.guess('<html><head><meta test="blah" http-equiv="content-type" content="text/html; charset=LATIN1"></head><body><div>hi!</div></body></html>')
       expect(guess).to eq("ISO-8859-1")
     end
 

--- a/spec/guess_html_encoding_spec.rb
+++ b/spec/guess_html_encoding_spec.rb
@@ -15,8 +15,13 @@ describe "GuessHtmlEncoding" do
       expect(guess).to eq("ISO-8859-1")
     end
 
-    it "accepts meta tags" do
-      guess = GuessHtmlEncoding.guess('<html><head><meta test="blah" http-equiv="content-type" content="text/html; charset=LATIN1"></head><body><div>hi!</div></body></html>')
+    it "accepts meta tags ending with ;" do
+      guess = GuessHtmlEncoding.guess('<html><head><meta test="blah" http-equiv="content-type" content="text/html; charset=LATIN1; "></head><body><div>hi!</div></body></html>')
+      expect(guess).to eq("ISO-8859-1")
+    end
+
+    it "accepts meta tags ending with space" do
+      guess = GuessHtmlEncoding.guess('<html><head><meta test="blah" http-equiv="content-type" content="text/html; charset=LATIN1 "></head><body><div>hi!</div></body></html>')
       expect(guess).to eq("ISO-8859-1")
     end
 


### PR DESCRIPTION
Existing code first looks for a `<meta http-equiv=“content-type”
content=“charset=”>` and then looks `<meta charset=“”>`. However there
are some edges cases where both types of meta tag are included, and
contradict each other.

In these cases, browser behaviour (and the HTML5) spec is to take the
first qualifying meta tag.

This updates the code to do that, by combining the two regular
expressions.