### PR TITLE
Regard Shift_JIS as Windows-31J

### DIFF
--- a/lib/guess_html_encoding.rb
+++ b/lib/guess_html_encoding.rb
@@ -32,6 +32,7 @@ module GuessHtmlEncoding
       out = "ISO-8859-1" if %w[LATIN1 LATIN-1].include?(out)
       out = "WINDOWS-1250" if %w[WIN-1251 WIN1251].include?(out)
       out = "GB18030" if %w[GB2312 GB18030].include?(out) 
+      out = "WINDOWS-31J" if %w[SHIFT_JIS SHIFT-JIS SJIS].include?(out)
     end
 
     out

--- a/spec/fixtures/shift_jis.html
+++ b/spec/fixtures/shift_jis.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=shift_jis" />
+</head>
+<body>
+  <div>
+    <!-- Shift_JIS characters -->
+    <p>Hi!1あア亜</p>
+  </div>
+</body>

--- a/spec/fixtures/windows-31j.html
+++ b/spec/fixtures/windows-31j.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=shift_jis" />
+</head>
+<body>
+  <div>
+    <!-- Shift_JIS characters -->
+    <p>Hi!1あア亜</p>
+    <!-- JIS X 0208-1990 characters -->
+    <p>√</p>
+    <!-- NEC special characters -->
+    <p>№</p>
+    <!-- IBM special characters -->
+    <p>髙</p>
+  </div>
+</body>

--- a/spec/guess_html_encoding_spec.rb
+++ b/spec/guess_html_encoding_spec.rb
@@ -146,7 +146,22 @@ describe "GuessHtmlEncoding" do
       guess = GuessHtmlEncoding.guess('<html><head><meta http-equiv="content-type" content="text/html; charset=GB2312;"></head><body><div>hi!</div></body></html>')
       expect(guess).to eq("GB18030")
     end
-    
+
+    it "translates Shift_JIS to WINDOWS-31J" do
+      guess = GuessHtmlEncoding.guess('<html><head><meta http-equiv="content-type" content="text/html; charset=shift_jis;"></head><body><div>hi!</div></body></html>')
+      expect(guess).to eq("WINDOWS-31J")
+    end
+
+    it "translates SHIFT-JIS to WINDOWS-31J" do
+      guess = GuessHtmlEncoding.guess('<html><head><meta http-equiv="content-type" content="text/html; charset=shift-jis;"></head><body><div>hi!</div></body></html>')
+      expect(guess).to eq("WINDOWS-31J")
+    end
+
+    it "translates SJIS to WINDOWS-31J" do
+      guess = GuessHtmlEncoding.guess('<html><head><meta http-equiv="content-type" content="text/html; charset=sjis;"></head><body><div>hi!</div></body></html>')
+      expect(guess).to eq("WINDOWS-31J")
+    end
+
     it "should not raise an exception if data is nil" do
       expect { GuessHtmlEncoding.guess(nil) }.not_to raise_error
     end

--- a/spec/guess_html_encoding_spec.rb
+++ b/spec/guess_html_encoding_spec.rb
@@ -218,10 +218,29 @@ describe "GuessHtmlEncoding" do
       expect(GuessHtmlEncoding.guess(data)).to eq("GB18030")
       expect(GuessHtmlEncoding.encode(data).encoding.to_s).to eq("GB18030")
     end
-    
+
     it "should work with headers as a hash" do
       data = File.read(File.join(File.dirname(__FILE__), "fixtures/gb18030.html"), :encoding => "binary")
       expect(lambda { GuessHtmlEncoding.encode(data, {}) }).not_to raise_error
+    end
+
+    it "should work on Windows-31J (and translate Shift_JIS into Windows-31J)" do
+      data = File.read(File.join(File.dirname(__FILE__), "fixtures/windows-31j.html"), :encoding => "binary")
+
+      # Shift_JIS don't includes Windows-31J special chars
+      expect(GuessHtmlEncoding.encode(data).encode("UTF-8")).to include("√", "№", "髙")
+      expect(GuessHtmlEncoding.encoding_loaded?("Windows-31J")).to be_truthy
+      expect(GuessHtmlEncoding.guess(data)).to eq("WINDOWS-31J")
+      expect(GuessHtmlEncoding.encode(data).encoding.to_s).to eq("Windows-31J")
+    end
+
+    it "should work on Shift_JIS (and translate Shift_JIS into Windows-31J)" do
+      data = File.read(File.join(File.dirname(__FILE__), "fixtures/shift_jis.html"), :encoding => "binary")
+
+      expect(GuessHtmlEncoding.guess(data)).to eq("WINDOWS-31J")
+      expect(GuessHtmlEncoding.encode(data).encoding.to_s).to eq("Windows-31J")
+      # Windows-31J includes Shift_JIS chars
+      expect(GuessHtmlEncoding.encode(data).encode("UTF-8")).to eq(GuessHtmlEncoding.encode(data).encode("UTF-8", "Shift_JIS"))
     end
   end
 


### PR DESCRIPTION
Change to translate Shift_JIS (Japanese character set) to Windows-31J (aka CP932).

Strictly speaking, a character set called `Shift_JIS` is `Windows-31J` and it often fails to encode as Shift_JIS.
