### PR TITLE
Fix mojibake when target text encoding is invalid

### DIFF
--- a/lib/guess_html_encoding.rb
+++ b/lib/guess_html_encoding.rb
@@ -45,7 +45,7 @@ module GuessHtmlEncoding
     if html_copy.valid_encoding?
       html_copy
     else
-      html_copy.force_encoding('ASCII-8BIT').encode('UTF-8', :undef => :replace, :invalid => :replace)
+      html_copy.encode('UTF-8', :undef => :replace, :invalid => :replace)
     end
   end
 

--- a/spec/guess_html_encoding_spec.rb
+++ b/spec/guess_html_encoding_spec.rb
@@ -167,8 +167,8 @@ describe "GuessHtmlEncoding" do
     end
 
     it "should work on incorrectly encoded pages" do
-      data = "<html><head><meta http-equiv='content-type' content='text/html; charset=utf8;'></head><body><div>hi!\xc2</div></body></html>"
-      replaced = "<html><head><meta http-equiv='content-type' content='text/html; charset=utf8;'></head><body><div>hi!\uFFFD</div></body></html>"
+      data = "<html><head><meta http-equiv='content-type' content='text/html; charset=utf8;'></head><body><div>hi!\xc2♥</div></body></html>"
+      replaced = "<html><head><meta http-equiv='content-type' content='text/html; charset=utf8;'></head><body><div>hi!\uFFFD♥</div></body></html>"
 
       data.force_encoding("ASCII-8BIT")
       expect(data).to be_valid_encoding # everything is valid in binary

--- a/spec/guess_html_encoding_spec.rb
+++ b/spec/guess_html_encoding_spec.rb
@@ -168,6 +168,8 @@ describe "GuessHtmlEncoding" do
 
     it "should work on incorrectly encoded pages" do
       data = "<html><head><meta http-equiv='content-type' content='text/html; charset=utf8;'></head><body><div>hi!\xc2</div></body></html>"
+      replaced = "<html><head><meta http-equiv='content-type' content='text/html; charset=utf8;'></head><body><div>hi!\uFFFD</div></body></html>"
+
       data.force_encoding("ASCII-8BIT")
       expect(data).to be_valid_encoding # everything is valid in binary
 
@@ -177,6 +179,8 @@ describe "GuessHtmlEncoding" do
       encoded = GuessHtmlEncoding.encode(data)
       expect(encoded.encoding.to_s).to eq("UTF-8")
       expect(encoded).to be_valid_encoding
+
+      expect(encoded).to eql replaced
     end
 
     it "should work on pages encoded with an unknown encoding by forcing them to utf8" do


### PR DESCRIPTION
If target text has a character which isn't included in character
set, transcoding to UFT-8 from ASCII-8BIT fails and all characters
are garbled to `U+FFFD`.